### PR TITLE
fix(static pages): handling multiple white spaces inside static page

### DIFF
--- a/docs/changelog/1.0.1.md
+++ b/docs/changelog/1.0.1.md
@@ -1,3 +1,4 @@
 # 1.0.1
 
 * [Bug]: Filter display as numeric index in mobile mode [#153](https://github.com/vuestorefront-community/vendure/issues/153)
+* [Bug]: Static pages doesn't handle properly multiple space occurrence inside title [#154](https://github.com/vuestorefront-community/vendure/issues/154)

--- a/packages/theme/pages/Static.vue
+++ b/packages/theme/pages/Static.vue
@@ -79,14 +79,14 @@ export default {
       const { pageName } = $route.params;
 
       if (pageName) {
-        return (pageName.charAt(0).toUpperCase() + pageName.slice(1)).replace('-', ' ');
+        return (pageName.charAt(0).toUpperCase() + pageName.slice(1)).replaceAll('-', ' ');
       }
 
       return 'About';
     });
 
     const changeActivePage = async (title) => {
-      $router.push(`/page/${(title || '').toLowerCase().replace(' ', '-')}`);
+      $router.push(`/page/${(title || '').toLowerCase().replaceAll(' ', '-')}`);
     };
 
     return { changeActivePage, activePage };


### PR DESCRIPTION
Fixed issue with handling only the first occurrence of white space in static page title

bug #154

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
