### PR TITLE
feat: add a new api-extension to handle localised content from Vendure API

### DIFF
--- a/docs/changelog/1.0.2.md
+++ b/docs/changelog/1.0.2.md
@@ -1,0 +1,1 @@
+[Feature]: implement localised content from Vendure api. [#142] https://github.com/vuestorefront-community/vendure/issues/142

--- a/packages/api-client/src/extensions/index.ts
+++ b/packages/api-client/src/extensions/index.ts
@@ -1,4 +1,5 @@
 import { ApiClientExtension } from '@vue-storefront/core';
 import { tokenExtension } from './token';
+import { localiseExtension } from './localiseConfig';
 
-export const extensions: ApiClientExtension[] = [tokenExtension];
+export const extensions: ApiClientExtension[] = [tokenExtension, localiseExtension];

--- a/packages/api-client/src/extensions/localiseConfig.ts
+++ b/packages/api-client/src/extensions/localiseConfig.ts
@@ -1,0 +1,20 @@
+
+import { ApiClientExtension } from '@vue-storefront/core';
+
+function getLocalisedUri(request, configuration) {
+  const originalUri = configuration.api.uri;
+  const api = {uri: originalUri + '?languageCode=' + request.cookies.i18n_redirected};
+  return { api };
+}
+
+export const localiseExtension: ApiClientExtension = {
+  name: 'localiseExtension',
+  hooks(request) {
+    return {
+      beforeCreate: ({ configuration }) => ({
+        ...configuration,
+        ...getLocalisedUri(request, configuration)
+      })
+    };
+  }
+};

--- a/packages/theme/components/LocaleSelector.vue
+++ b/packages/theme/components/LocaleSelector.vue
@@ -1,0 +1,112 @@
+<template>
+  <div class="container">
+    <SfButton
+        class="container__lang container__lang--selected"
+        @click="isLangModalOpen = !isLangModalOpen"
+    >
+      <SfImage :src="`/icons/langs/${locale}.webp`" width="20" alt="Flag" />
+    </SfButton>
+    <SfBottomModal :is-open="isLangModalOpen" title="Choose language" @click:close="isLangModalOpen = !isLangModalOpen"> 
+      <SfList>
+        <SfListItem v-for="lang in availableLocales" :key="lang.code">          
+           <a @click="languageSwitcher(lang.code)" href="#">
+            <SfCharacteristic class="language">
+              <template #title>
+                <span>{{ lang.label }}</span>
+              </template>
+              <template #icon>
+                <SfImage :src="`/icons/langs/${lang.code}.webp`" width="20" alt="Flag" class="language__flag" />
+              </template>
+            </SfCharacteristic>
+          </a>
+        </SfListItem>
+      </SfList>
+    </SfBottomModal>
+  </div>
+</template>
+
+<script>
+import {
+  SfImage,
+  SfSelect,
+  SfButton,
+  SfList,
+  SfBottomModal,
+  SfCharacteristic
+} from '@storefront-ui/vue';
+
+import { ref, computed} from '@vue/composition-api';
+export default {
+  components: {
+    SfImage,
+    SfSelect,
+    SfButton,
+    SfList,
+    SfBottomModal,
+    SfCharacteristic
+  },
+  setup(props, context) {
+    const { locales, locale } = context.root.$i18n;
+    const isLangModalOpen = ref(false);
+    const availableLocales = computed(() => locales.filter(i => i.code !== locale));
+    const languageSwitcher = (lang) => {
+      console.log(lang)
+      context.root.$i18n.setLocale(lang)
+      context.root.switchLocalePath(lang)
+      window.location.reload();
+      isLangModalOpen.value = !isLangModalOpen     
+
+    }
+    
+    return {
+      availableLocales,
+      locale,
+      isLangModalOpen,
+      languageSwitcher
+      
+    };
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+.container {
+  margin: 0 -5px;
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: center;
+  position: relative;
+  .sf-bottom-modal {
+    z-index: 2;
+    left: 0;
+    @include for-desktop {
+      --bottom-modal-height: 100vh;
+    }
+  }
+  .sf-list {
+    .language {
+      padding: var(--spacer-sm);
+      &__flag {
+        margin-right: var(--spacer-sm);
+      }
+    }
+    @include for-desktop {
+      display: flex;
+    }
+  }
+  &__lang {
+    width: 20px;
+    --button-box-shadow: none;
+    background: none;
+    padding: 0 5px;
+    display: flex;
+    align-items: center;
+    opacity: 0.5;
+    border: none;
+    &:hover,
+    &--selected {
+      opacity: 1;
+    }
+  }
+}
+</style>

--- a/packages/theme/components/LocaleSelector.vue
+++ b/packages/theme/components/LocaleSelector.vue
@@ -6,9 +6,9 @@
     >
       <SfImage :src="`/icons/langs/${locale}.webp`" width="20" alt="Flag" />
     </SfButton>
-    <SfBottomModal :is-open="isLangModalOpen" title="Choose language" @click:close="isLangModalOpen = !isLangModalOpen"> 
+    <SfBottomModal :is-open="isLangModalOpen" title="Choose language" @click:close="isLangModalOpen = !isLangModalOpen">
       <SfList>
-        <SfListItem v-for="lang in availableLocales" :key="lang.code">          
+        <SfListItem v-for="lang in availableLocales" :key="lang.code">
            <a @click="languageSwitcher(lang.code)" href="#">
             <SfCharacteristic class="language">
               <template #title>
@@ -50,20 +50,19 @@ export default {
     const isLangModalOpen = ref(false);
     const availableLocales = computed(() => locales.filter(i => i.code !== locale));
     const languageSwitcher = (lang) => {
-      console.log(lang)
-      context.root.$i18n.setLocale(lang)
-      context.root.switchLocalePath(lang)
+      context.root.$i18n.setLocale(lang);
+      context.root.switchLocalePath(lang);
       window.location.reload();
-      isLangModalOpen.value = !isLangModalOpen     
+      isLangModalOpen.value = !isLangModalOpen;
 
-    }
-    
+    };
+
     return {
       availableLocales,
       locale,
       isLangModalOpen,
       languageSwitcher
-      
+
     };
   }
 };

--- a/packages/theme/nuxt.config.js
+++ b/packages/theme/nuxt.config.js
@@ -92,7 +92,7 @@ export default {
     lazy: true,
     seo: true,
     langDir: 'lang/',
-    strategy: 'prefix',
+    strategy: 'no_prefix',
     vueI18n: {
       fallbackLocale: 'en',
       numberFormats: {

--- a/packages/theme/nuxt.config.js
+++ b/packages/theme/nuxt.config.js
@@ -92,7 +92,7 @@ export default {
     lazy: true,
     seo: true,
     langDir: 'lang/',
-    strategy: 'no_prefix',
+    strategy: 'prefix',
     vueI18n: {
       fallbackLocale: 'en',
       numberFormats: {


### PR DESCRIPTION
get Localised content from Vendure shop-API 

## Description
add a new api-extension file : packages/api-client/src/extensions/localiseConfig.ts : 
- catch the api client request
- gets the language code from the client cookie 'i18n_redirected' value.
- add the <&languageCode=...> extension to the initial api.uri

Also updated the i18_n parameter 'strategy' : 'prefix' to correct the language switching bug

## Related Issue
 https://github.com/vuestorefront-community/vendure/issues/142


## Motivation and Context
Localised content from Vendure e-commerce

## How Has This Been Tested?
- When you switch language, you need to reload the entire url the browser in order to refresh all the modules with the correct localised data.
- **we need to find a way to dynamically refresh all the content after a language switch...**

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
