### PR TITLE
fix: sizes of images in related products component

### DIFF
--- a/docs/changelog/1.2.0.md
+++ b/docs/changelog/1.2.0.md
@@ -1,0 +1,3 @@
+# 1.2.0
+
+* [Bug]: sizes of images in related products component [#172](https://github.com/vuestorefront-community/vendure/pull/172)

--- a/packages/theme/components/RelatedProducts.vue
+++ b/packages/theme/components/RelatedProducts.vue
@@ -11,6 +11,7 @@
             :image="product.productAsset.preview"
             :regular-price="$n(getCalculatedPrice(product.price.max), 'currency')"
             :link="localePath(`/p/${product.productId}/${product.slug}`)"
+            class="carousel__item-image"
           />
         </SfCarouselItem>
       </SfCarousel>
@@ -61,9 +62,14 @@ export default {
   &__item {
     margin: 1.9375rem 0 2.4375rem 0;
   }
-
   ::v-deep .sf-product-card__image .sf-image {
-    --image-height: unset;
+    --image-height: 230px;
+    --image-width: 150px;
+    object-fit: cover;
+    @include for-desktop {
+      --image-width: 210px;
+      --image-height: 340px;
+    }
   }
 }
 


### PR DESCRIPTION
## Description
Fixed sizes of images on Related Products component to be equal for mobile and desktop views. 

## Related Issue
#166

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
