### PR TITLE
fix: BottomNavigation, AppHeader - center items and add mobile menu

### DIFF
--- a/docs/changelog/1.2.0.md
+++ b/docs/changelog/1.2.0.md
@@ -3,3 +3,4 @@
 * [Bug]: sizes of images in related products component [#172](https://github.com/vuestorefront-community/vendure/pull/172)
 * [Bug]: Project is not building [#176](https://github.com/vuestorefront-community/vendure/issues/176)
 * [Docs]: Update README.md [#177](https://github.com/vuestorefront-community/vendure/issues/177)
+* [Bug]: BottomNavigation on mobile is moved to the left, and cannot open the mobile menu [#184](https://github.com/vuestorefront-community/vendure/issues/184)

--- a/packages/theme/components/AppHeader.vue
+++ b/packages/theme/components/AppHeader.vue
@@ -11,14 +11,33 @@
         </nuxt-link>
       </template>
       <template #navigation>
-        <SfHeaderNavigationItem
-          v-for="category in headerNavigation"
-          :key="category.name"
-          class="nav-item"
-          v-e2e="`app-header-${category.name}`"
-          :label="category.name"
-          :link="localePath(`/c/${category.link}`)"
-        />
+        <div class="sf-header__navigation desktop" v-if="!isMobile">
+          <SfHeaderNavigationItem
+            v-for="category in headerNavigation"
+            :key="category.name"
+            class="nav-item"
+            v-e2e="`app-header-${category.name}`"
+            :label="category.name"
+            :link="localePath(`/c/${category.link}`)"
+          />
+        </div>
+        <SfModal v-else :visible="isMobileMenuOpen" title="Menu" @close="toggleMobileMenu">
+          <SfList>
+            <SfListItem
+              v-for="category in headerNavigation"
+              :key="category.name"
+              class="nav-item sf-header-navigation-item"
+              v-e2e="`app-header-url_${category.link}`"
+            >
+              <SfMenuItem
+                :label="category.name"
+                class="sf-header-navigation-item__menu-item"
+                :link="localePath(`/c/${category.link}`)"
+                @click.native="toggleMobileMenu"
+              />
+            </SfListItem>
+          </SfList>
+        </SfModal>
       </template>
       <template #aside>
         <LocaleSelector class="smartphone-only" />
@@ -107,7 +126,7 @@
 </template>
 
 <script>
-import { SfHeader, SfImage, SfIcon, SfButton, SfBadge, SfSearchBar, SfOverlay, SfMenuItem, SfLink } from '@storefront-ui/vue';
+import { SfHeader, SfImage, SfIcon, SfButton, SfBadge, SfSearchBar, SfOverlay, SfMenuItem, SfLink, SfModal, SfList } from '@storefront-ui/vue';
 import { useUiState, useUiHelpers } from '~/composables';
 import { useCart, useWishlist, useUser, cartGetters, wishlistGetters, useCategory, categoryGetters, useFacet } from '@vue-storefront/vendure';
 import { computed, ref, onBeforeUnmount, watch } from '@vue/composition-api';
@@ -133,11 +152,13 @@ export default {
     SearchResults,
     SfOverlay,
     SfMenuItem,
-    SfLink
+    SfLink,
+    SfModal,
+    SfList
   },
   directives: { clickOutside },
   setup(props, { root }) {
-    const { toggleCartSidebar, toggleWishlistSidebar, toggleLoginModal, isMobileMenuOpen } = useUiState();
+    const { toggleCartSidebar, toggleWishlistSidebar, toggleLoginModal, isMobileMenuOpen, toggleMobileMenu } = useUiState();
     const { setTermForUrl, getFacetsFromURL } = useUiHelpers();
     const { isAuthenticated, load: loadUser } = useUser();
     const { cart, load: loadCart } = useCart();
@@ -241,7 +262,8 @@ export default {
       removeSearchResults,
       headerNavigation,
       isMobileMenuOpen,
-      wishlistTotalItems
+      wishlistTotalItems,
+      toggleMobileMenu
     };
   }
 };

--- a/packages/theme/components/AppHeader.vue
+++ b/packages/theme/components/AppHeader.vue
@@ -21,7 +21,7 @@
             :link="localePath(`/c/${category.link}`)"
           />
         </div>
-        <SfModal v-else :visible="isMobileMenuOpen" title="Menu" @close="toggleMobileMenu">
+        <SfModal v-else :visible="isMobileMenuOpen" :title="$t('Menu')" @close="toggleMobileMenu">
           <SfList>
             <SfListItem
               v-for="category in headerNavigation"

--- a/packages/theme/components/BottomNavigation.vue
+++ b/packages/theme/components/BottomNavigation.vue
@@ -1,0 +1,70 @@
+<template>
+<!-- TODO: create logic with isActive prop for BottomNavigationItems -->
+  <SfBottomNavigation class="navigation-bottom smartphone-only">
+      <SfBottomNavigationItem
+        :class="$route.path == '/' ? 'sf-bottom-navigation__item--active' : ''"
+        icon="home" size="20px" label="Home"
+        @click="handleHomeClick"
+      />
+    <SfBottomNavigationItem icon="menu" size="20px" label="Menu" @click="toggleMobileMenu"/>
+    <SfBottomNavigationItem icon="heart" size="20px" label="Wishlist" @click="toggleWishlistSidebar"/>
+    <SfBottomNavigationItem icon="profile" size="20px" label="Account" @click="handleAccountClick"/>
+    <!-- TODO: add logic for label - if on Home then Basket, if on PDC then AddToCart etc. -->
+    <SfBottomNavigationItem
+      label="Basket"
+      icon="add_to_cart"
+      @click="toggleCartSidebar"
+    >
+      <template #icon>
+        <SfCircleIcon aria-label="Add to cart">
+          <SfIcon
+            icon="add_to_cart"
+            color="white"
+            size="25px"
+            :style="{margin: '0 0 0 -2px'}"
+          />
+        </SfCircleIcon>
+      </template>
+    </SfBottomNavigationItem>
+  </SfBottomNavigation>
+</template>
+
+<script>
+import { SfBottomNavigation, SfIcon, SfCircleIcon } from '@storefront-ui/vue';
+import { useUiState } from '~/composables';
+import { useUser } from '@vue-storefront/vendure';
+export default {
+  components: {
+    SfBottomNavigation,
+    SfIcon,
+    SfCircleIcon
+  },
+  setup(props, { root }) {
+    const { toggleCartSidebar, toggleWishlistSidebar, toggleLoginModal, toggleMobileMenu, isMobileMenuOpen } = useUiState();
+    const { isAuthenticated } = useUser();
+    const handleAccountClick = async () => {
+      if (isAuthenticated.value) {
+        return root.$router.push('/my-account');
+      }
+      toggleLoginModal();
+    };
+    const handleHomeClick = () => {
+      isMobileMenuOpen.value ? toggleMobileMenu() : false;
+      root.$router.push('/');
+    };
+    return {
+      isMobileMenuOpen,
+      toggleWishlistSidebar,
+      toggleCartSidebar,
+      toggleMobileMenu,
+      handleAccountClick,
+      handleHomeClick
+    };
+  }
+};
+</script>
+<style lang="scss" scoped>
+.navigation-bottom {
+  --bottom-navigation-z-index: 3;
+}
+</style>

--- a/packages/theme/components/BottomNavigation.vue
+++ b/packages/theme/components/BottomNavigation.vue
@@ -3,15 +3,17 @@
   <SfBottomNavigation class="navigation-bottom smartphone-only">
       <SfBottomNavigationItem
         :class="$route.path == '/' ? 'sf-bottom-navigation__item--active' : ''"
-        icon="home" size="20px" label="Home"
+        icon="home"
+        size="20px"
+        label="Home"
         @click="handleHomeClick"
       />
-    <SfBottomNavigationItem icon="menu" size="20px" label="Menu" @click="toggleMobileMenu"/>
-    <SfBottomNavigationItem icon="heart" size="20px" label="Wishlist" @click="toggleWishlistSidebar"/>
-    <SfBottomNavigationItem icon="profile" size="20px" label="Account" @click="handleAccountClick"/>
+    <SfBottomNavigationItem icon="menu" size="20px" :label="$t('Menu')" @click="toggleMobileMenu"/>
+    <SfBottomNavigationItem icon="heart" size="20px" :label="$t('Wishlist')" @click="toggleWishlistSidebar"/>
+    <SfBottomNavigationItem icon="profile" size="20px" :label="$t('Account')" @click="handleAccountClick"/>
     <!-- TODO: add logic for label - if on Home then Basket, if on PDC then AddToCart etc. -->
     <SfBottomNavigationItem
-      label="Basket"
+      :label="$t('Basket')"
       icon="add_to_cart"
       @click="toggleCartSidebar"
     >

--- a/packages/theme/lang/de.js
+++ b/packages/theme/lang/de.js
@@ -170,5 +170,9 @@ export default {
   'Primary contacts for any questions': 'Primäre Ansprechpartner bei Fragen',
   'Your Account': 'Ihr Konto',
   'What can we improve': 'Was können wir verbessern',
-  'Update email': 'E-Mail aktualisieren'
+  'Update email': 'E-Mail aktualisieren',
+  'Menu': "Menu",
+  'Wishlist': 'Wunschliste',
+  'Account': 'Konto',
+  'Basket': 'Warenkorb'
 };

--- a/packages/theme/lang/en.js
+++ b/packages/theme/lang/en.js
@@ -170,5 +170,9 @@ export default {
   'Primary contacts for any questions': 'Primary contacts for any questions',
   'Your Account': 'Your Account',
   'What can we improve': 'What can we improve',
-  'Update email': 'Update email'
+  'Update email': 'Update email',
+  'Menu': "Menu",
+  'Wishlist': 'Wishlist',
+  'Account': 'Account',
+  'Basket': 'Basket'
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added mobile menu in AppHeader to be opened on click in Bottom Navigation. 
BottomNavigation items centered. 

## Related Issue
#184 

## Motivation and Context


## How Has This Been Tested?

## Screenshots (if appropriate):
![vendure_mobile_menu](https://user-images.githubusercontent.com/32042425/156765774-496e1071-5bcf-4a94-9bbd-7b5a186795a1.gif)

## Types of changes


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
