### PR TITLE
feat: expose createStripePaymentIntent through api

### DIFF
--- a/packages/api-client/src/api/createStripePaymentIntent/createStripePaymentIntentMutation.ts
+++ b/packages/api-client/src/api/createStripePaymentIntent/createStripePaymentIntentMutation.ts
@@ -1,0 +1,7 @@
+import gql from 'graphql-tag';
+
+export default gql`
+  mutation createStripePaymentIntent {
+    createStripePaymentIntent
+  }
+`;

--- a/packages/api-client/src/api/createStripePaymentIntent/index.ts
+++ b/packages/api-client/src/api/createStripePaymentIntent/index.ts
@@ -1,0 +1,23 @@
+import gql from 'graphql-tag';
+import createStripePaymentIntentMutation from './createStripePaymentIntentMutation';
+import { CustomQuery } from '@vue-storefront/core';
+import { Context } from '../../types';
+import { NO_CACHE_FETCH_POLICY } from '../../helpers/constants';
+import { ApolloQueryResult } from 'apollo-client';
+
+const createStripePaymentIntent = async (context: Context, customQuery?: CustomQuery): Promise<ApolloQueryResult<string>> => {
+
+  const { createStripePaymentIntent } = context.extendQuery(
+    customQuery, { createStripePaymentIntent: { query: createStripePaymentIntentMutation, variables: {} } }
+  );
+
+  const request = await context.client.query<string>({
+    query: gql`${createStripePaymentIntent.query}`,
+    variables: {},
+    fetchPolicy: NO_CACHE_FETCH_POLICY
+  });
+  return request;
+
+};
+
+export default createStripePaymentIntent;


### PR DESCRIPTION

## Description

in case you use [the vendure stripe plugin](https://www.vendure.io/docs/typescript-api/payments-plugin/stripe-plugin/) you will need to call the `createStripePaymentIntent` mutation which requires the current session token.

We can't call this mutation directly from the frontend, instead we want to use the existing routing through nuxt's api

## Related Issue

will update

## Motivation and Context

helps using the vue storefront with stripe and vendure

## How Has This Been Tested?

ongoing

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
