### PR TITLE
fix: country state on billing step not getting persisted upon selection

### DIFF
--- a/docs/changelog/1.2.0.md
+++ b/docs/changelog/1.2.0.md
@@ -5,3 +5,4 @@
 * [Docs]: Update README.md [#177](https://github.com/vuestorefront-community/vendure/issues/177)
 * [Bug]: BottomNavigation on mobile is moved to the left, and cannot open the mobile menu [#184](https://github.com/vuestorefront-community/vendure/issues/184)
 * [Feature]: Replace mocked products in carousel on Home page [#165](https://github.com/vuestorefront-community/vendure/issues/165)
+* [Bug]: Country state on billing step not getting persisted upon selection [#194](https://github.com/vuestorefront-community/vendure/pull/194)

--- a/packages/theme/pages/Checkout/Billing.vue
+++ b/packages/theme/pages/Checkout/Billing.vue
@@ -121,7 +121,7 @@
         >
           <SfSelect
             v-e2e="'billing-country'"
-            :value="billingDetails.country"
+            v-model="billingDetails.country"
             :label="$t('Country')"
             name="country"
             class="form__element form__element--half form__select sf-select--underlined"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes a bug where the state for the country select field on the checkout billing step does not change upon selection

## Related Issue

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
