### PR TITLE
fix: continue to payment whatever the shipping price is

### DIFF
--- a/docs/changelog/1.2.0.md
+++ b/docs/changelog/1.2.0.md
@@ -7,3 +7,4 @@
 * [Feature]: Replace mocked products in carousel on Home page [#165](https://github.com/vuestorefront-community/vendure/issues/165)
 * [Bug]: Country state on billing step not getting persisted upon selection [#194](https://github.com/vuestorefront-community/vendure/pull/194)
 * [Bug]: Only featured image used to be displayed on product page [#195](https://github.com/vuestorefront-community/vendure/issues/195)
+* [Bug]: Cannot continue to payment if shipping price i 0 [#199](https://github.com/vuestorefront-community/vendure/issues/199)

--- a/packages/theme/helpers/checkout.ts
+++ b/packages/theme/helpers/checkout.ts
@@ -8,7 +8,7 @@ export const canEnterShipping = (cart: Order): boolean => Boolean(cart?.customer
 
 export const canEnterBilling = (cart: Order): boolean => Boolean(cart?.shippingAddress?.streetLine1 && cart?.shippingAddress?.country);
 
-export const canEnterPayment = (cart: Order): boolean => canEnterShipping(cart) && canEnterBilling(cart) && cart?.shipping && cart?.state === ARRANGING_PAYMENT;
+export const canEnterPayment = (cart: Order): boolean => canEnterShipping(cart) && canEnterBilling(cart) && cart?.shippingLines?.[0]?.shippingMethod?.code && cart?.state === ARRANGING_PAYMENT;
 
 export enum CheckoutSteps {
   Shipping = 'shipping',


### PR DESCRIPTION

## Description
Currently you cannot continue to payment page if you shipping price is 0

## Related Issue
Closes #199 

## Motivation and Context

## How Has This Been Tested?


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ X] All new and existing tests passed.
