### PR TITLE
Fixing bug in shippingMethodId is ID! instead of [ID!]! 

### DIFF
--- a/packages/api-client/src/api/setShippingMethod/setOrderShippingMethodMutation.ts
+++ b/packages/api-client/src/api/setShippingMethod/setOrderShippingMethodMutation.ts
@@ -5,7 +5,7 @@ export default gql`
   ${CartFragment}
   ${ErrorResultFragment}
 
-  mutation setOrderShippingMethod($shippingMethodId: ID!) {
+  mutation setOrderShippingMethod($shippingMethodId: [ID!]!) {
     setOrderShippingMethod(shippingMethodId: $shippingMethodId) {
       ...Cart
       ...ErrorResult


### PR DESCRIPTION
Fixing bug in shippingMethodId is ID! instead of [ID!]!  in setOrderShippingMethodMutation.ts when integrating with vendure v2.1.6

## Description
Following error was happening with vendure 2.1.6 using vuestorefront with vendure integration: [VSF][error]:  [GraphQL error]: Message: Variable "$shippingMethodId" of type "ID!" used in position expecting type "[ID!]!"., Location: [column: 33, line: 119], [column: 44, line: 120], Path: undefined

Noticed the issue was due to the fact that the variable shippingMethodId in node_module folder @vue-storefront > vendure-api > server > index.js had the wrong type set for shippingMethodId which was crashing vue-storefront app when trying to order and setting the shipping method

## Related Issue
(https://github.com/vuestorefront-community/vendure/issues/244)

## Motivation and Context
You basically cannot place any order to the vendure integration does not work

## How Has This Been Tested?
Change the code in the node_module index.js file that was generated code and it start working (meaning i could place an order)

## Screenshots (if appropriate):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
